### PR TITLE
feat: Add PATCH and DELETE API routes for editing and deleting form entries

### DIFF
--- a/controllers/formController.js
+++ b/controllers/formController.js
@@ -7,7 +7,15 @@ const submitForm = (req, res) => {
     return res.status(400).json({ message: 'Missing required fields.' });
   }
 
-  const newEntry = { id: Date.now(), name, email, age, gender, comment };
+  const newEntry = {
+    id: Date.now().toString(),
+    name, 
+    email,
+    age,
+    gender,
+    comment,
+  };
+
   formDataStore.push(newEntry);
 
   res.status(201).json({ message: 'Form submitted successfully.', entry: newEntry });
@@ -17,4 +25,41 @@ const getAllData = (req, res) => {
   res.status(200).json({ data: formDataStore });
 };
 
-module.exports = { submitForm, getAllData, formDataStore };
+const updateEntry = (req, res) => {
+  const { id } = req.params;
+  const updates = req.body;
+
+  const index = formDataStore.findIndex((entry) => entry.id === id);
+  if (index === -1) {
+    return res.status(404).json({ message: 'Entry not found.' });
+  }
+
+  // Update only the provided fields
+  formDataStore[index] = {
+    ...formDataStore[index],
+    ...updates,
+  };
+
+  res.status(200).json({ message: 'Entry updated successfully.', entry: formDataStore[index] });
+};
+
+const deleteEntry = (req, res) => {
+  const { id } = req.params;
+  const index = formDataStore.findIndex((entry) => entry.id === id);
+
+  if (index === -1) {
+    return res.status(404).json({ message: 'Entry not found.' });
+  }
+
+  formDataStore.splice(index, 1);
+
+  res.status(200).json({ message: 'Entry deleted successfully.' });
+};
+
+module.exports = {
+  submitForm,
+  getAllData,
+  updateEntry,
+  deleteEntry,
+  formDataStore,
+};

--- a/routes/formRoutes.js
+++ b/routes/formRoutes.js
@@ -1,10 +1,16 @@
 const express = require('express');
-const { submitForm, getAllData  } = require('../controllers/formController');
+const {
+  submitForm,
+  getAllData,
+  updateEntry,
+  deleteEntry,
+} = require('../controllers/formController');
 
 const router = express.Router();
 
 router.post('/submit', submitForm);
-
 router.get('/data', getAllData);
+router.patch('/update/:id', updateEntry);
+router.delete('/delete/:id', deleteEntry);
 
 module.exports = router;


### PR DESCRIPTION
### What Changed
- Added `PATCH /api/update/:id` route in `formRoutes.js` to allow partial updates of form entries.
- Implemented `updateEntry` in `formController.js` using the spread operator to merge updates with existing data.
- Added `DELETE /api/delete/:id` route in `formRoutes.js` to delete a form entry by its ID.
- Implemented `deleteEntry` function in `formController.js` to handle deletion from in-memory store.
- Updated route exports to include new endpoints.

### Why
These changes introduce essential CRUD operations — update and delete — enhancing the usability of the form data API. This allows users to correct or remove entries as needed, supporting the full lifecycle of a form submission.

### Testing
- Manually tested `PATCH` with partial payloads to ensure only specific fields are updated.
- Verified that `DELETE` removes the correct entry and responds appropriately when ID is not found.
- Confirmed server response codes and messages align with expectations.